### PR TITLE
SSHI: Code maint. Docs cleanup. Timeout for tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,105 +1,105 @@
-# bashrc_enhancements
-Some useful functions, shortcuts, and enhancements to add to your .bashrc (or .bash_profile).
+# bashrc\_enhancements
+Some useful functions, shortcuts, and enhancements to add to your \.bashrc \(or \.bash\_profile\)\.
 
-Current functions are called *addpath*, *sudo*, and *tar*.
-*sudo* and *tar* are "intercept" functions, which are used to add functionality to existing commands of the same name.
+Current functions are called *addpath*, *sudo*, and *tar*\.
+*sudo* and *tar* are "intercept" functions, which are used to add functionality to existing commands of the same name\.
 
-## addpath - Keep your PATH clean.
+## addpath \- Keep your PATH clean\.
 
-This function will (intelligently) add a directory to your PATH, with conditions:
-1. Item will only be added if it exists and is a directory (Handy when you want to use the same .bashrc across dissimilar systems).
-2. If the item already exists in PATH, its location in PATH is changed or removed (Useful if required to reference the same .bashrc from nested bash shells).
+This function will \(intelligently\) add a directory to your PATH, with conditions:
+1. Item will only be added if it exists and is a directory \(Handy when you want to use the same .bashrc across dissimilar systems\)\.
+2. If the item already exists in PATH, its location in PATH is changed or removed \(Useful if required to reference the same .bashrc from nested bash shells\)\.
 
 __Available options:__
 *The following arguments are optional:*
-* first  - Add the entry before all other entries in PATH.
-* remove - Remove any references to the entry from PATH.
+* first  \- Add the entry before all other entries in PATH\.
+* remove \- Remove any references to the entry from PATH\.
 
-* _If no options are specified, the entry is appended to the end of PATH._
+* _If no options are specified, the entry is appended to the end of PATH\._
 
 ### Syntax examples:
 *SCENARIO:*
-* The original value of PAbring it with you to remote SSH sessions.
+* The original value of PAbring it with you to remote SSH sessions\.
 ```
 addpath /usr/bin first
-* _Value of PATH becomes "/usr/bin:/bin:/home/zish/bar"._
+* _Value of PATH becomes "/usr/bin:/bin:/home/zish/bar"\._
 addpath /usr/local/sbin
-* _Value of PATH becomes "/usr/bin:/bin:/home/zish/bar:/usr/local/sbin"._
+* _Value of PATH becomes "/usr/bin:/bin:/home/zish/bar:/usr/local/sbin"\._
 addpath /usr/local/sbin
-* _Value of PATH _remains_ "/usr/bin:/bin:/home/zish/bar:/usr/local/sbin"._
+* _Value of PATH remains "/usr/bin:/bin:/home/zish/bar:/usr/local/sbin"\._
 addpath ${HOME}/bar remove
-* _Value of PATH becomes "/usr/bin:/bin:/usr/local/sbin"._
+* _Value of PATH becomes "/usr/bin:/bin:/usr/local/sbin"\._
 addpath ${HOME}/foo first
-* _If "${HOME}/foo" exists, PATH becomes "/usr/bin:/bin:/usr/local/sbin:/home/zish/foo"._
-* _If "${HOME}/foo" does not exist, PATH remains "/usr/bin:/bin:/usr/local/sbin"._
+* _If "${HOME}/foo" exists, PATH becomes "/usr/bin:/bin:/usr/local/sbin:/home/zish/foo"\._
+* _If "${HOME}/foo" does not exist, PATH remains "/usr/bin:/bin:/usr/local/sbin"\._
 ```
 
-## ssh - SSH interception subroutine with a lot of great extras.
+## ssh \- SSH interception subroutine with a lot of great extras\.
 
-This was written originally as a mechanism to bring my locally-defined PS1 prompt and  bash aliases with me, so I didn't need to copy them everywhere. It has since had a lot more functionality added to it.
+This was written originally as a mechanism to bring my locally\-defined PS1 prompt and  bash aliases with me, so I didn't need to copy them everywhere\. It has since had a lot more functionality added to it\.
 
 ### Features:
-* Define PS1 locally, and have it appear in remote SSH sessions.
-* Use locally-defined aliases in remote SSH sessions.
-* Use locally-defined subroutines in remote SSH sessions (must be explicity defined).
-* Arbitrarily add sections from your local bashrc as needed.
-* Automaticallly log output from SSH sessions.
-* _Ability to override these options for hosts._
-..* _Overrides are specified as a comment at the end of a 'Host' line that matches the host, in your ~/.ssh/config file._
+* Define PS1 locally, and have it appear in remote SSH sessions\.
+* Use locally\-defined aliases in remote SSH sessions\.
+* Use locally\-defined subroutines in remote SSH sessions \(must be explicity defined\)\.
+* Arbitrarily add sections from your local bashrc as needed\.
+* Automaticallly log output from SSH sessions\.
+* _Ability to override these options for hosts\._
+..* _Overrides are specified as a comment at the end of a 'Host' line that matches the host, in your ~/\.ssh/config file\._
 
-### See README.ssh.md file for configuration and usage.
+### See README\.ssh\.md file for configuration and usage\.
 
 
-## sudo - SUDO interception command. This allows you to use available aliases with the sudo command.
+## sudo \- SUDO interception command\. This allows you to use available aliases with the sudo command\.
 
-This will intercept the "sudo" command. If the command executed by sudo matches a defined alias, it will execute the contents of the alias instead.
+This will intercept the "sudo" command\. If the command executed by sudo matches a defined alias, it will execute the contents of the alias instead\.
 
 ### Examples:
 
-_In .bashrc:_
+_In \.bashrc:_
 
-alias tlog='tail -100 /var/log/syslog'
+alias tlog='tail \-100 /var/log/syslog'
 
-Normally this alias would need to be defined in root's .bashrc file to be used. Even still, there may be security controls restricting what may be available from a sudo command, or tools that manage the integrity of root's .bashrc entirely. Thus running "sudo tlog" would fail with a "command not found" error.
+Normally this alias would need to be defined in root's \.bashrc file to be used\. Even still, there may be security controls restricting what may be available from a sudo command, or tools that manage the integrity of root\'s \.bashrc entirely\. Thus running "sudo tlog" would fail with a "command not found" error\.
 
-The sudo intercept function instead will rewrite the sudo command appropriately. The command "sudo tlog" gets invoked as "sudo tail -100 /var/log/syslog".
+The sudo intercept function instead will rewrite the sudo command appropriately\. The command "sudo tlog" gets invoked as "sudo tail \-100 /var/log/syslog"\.
 
 
-## tar - Tar interception command. Suppresses annoying "SCHILY" messages when extracting a TAR archive originating from a MacOS system.
+## tar \- Tar interception command\. Suppresses annoying "SCHILY" messages when extracting a TAR archive originating from a MacOS system\.
 
-This is primarily intended for Linux systems, but can be used for any system with GNU/Tar.
+This is primarily intended for Linux systems, but can be used for any system with GNU/Tar\.
 This cuts down the amount of output echoed to your terminal or output log,
-and is expecially useful when extracting a tar file from MacOS with a lot of files.
+and is expecially useful when extracting a tar file from MacOS with a lot of files\.
 
 
 ## Installation:
 
 *Simple method:*
 
-Copy the contents of this repo to ${HOME}/.bashrc_enhancements
-Add the text ". ${HOME}/.bashrc_enhancements/bashrc" on a blank line in your .bashrc (or .bash_profile)
-near the beginning of the file.
+Copy the contents of this repo to \$\{HOME\}/\.bashrc\_enhancements
+Add the text "\. \$\{HOME\}/\.bashrc\_enhancements/bashrc" on a blank line in your \.bashrc \(or \.bash\_profile\)
+near the beginning of the file\.
 
 
 *Portable method:*
 
-The simple method requires that ${HOME}/.bashrc_enhancements be made available on any system that you
-wish to use it on. As an alternative, the contents of any file under ${HOME}/.bashrc_enhancements/files
-can be added directly to your .bashrc file.
+The simple method requires that \$\{HOME\}/\.bashrc\_enhancements be made available on any system that you
+wish to use it on\. As an alternative, the contents of any file under \$\{HOME\}/\.bashrc\_enhancements/files
+can be added directly to your \.bashrc file\.
 
 
 ## License:
 
-_bashrc_enhancements_ is free software: you can redistribute it and/or modify
+_bashrc\_enhancements_ is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+\(at your option\) any later version\.
 
-_bashrc_enhancements_ is distributed in the hope that it will be useful,
+_bashrc\_enhancements_ is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE\. See the
+GNU Affero General Public License for more details\.
 
 A copy of the GNU Affero General Public License should be provided along
-with _bashrc_enhancements_. If not, see <http://www.gnu.org/licenses/>.
+with _bashrc\_enhancements_\. If not, see <http://www\.gnu\.org/licenses/>\.
 

--- a/README.ssh.md
+++ b/README.ssh.md
@@ -18,17 +18,8 @@ This was written originally as a mechanism to bring my locally\-defined PS1 prom
 _Default:_
 * SSHI\_ADD\_SUBS="sudo ssh tar addpath"
 
-### SSHI\_INC\_FILES \- Associative array containing files to include with the shipped SSH Session\.
-_Default:_
-SSHI\_INC\_FILES=\(\)
-
-How to declare files:
-
-SSHI\_INC\_FILES=\("$\{HOME\}/\.vimrc" '$\{HOME\}/\.vimrc'\)
-*Note the use of single versus double\-quotes\. Using single will avoid expanding the value of the local variable\.*
-
 ### SSHI\_RPS1 \- Remote PS1 Prompt\.
-The default prepends the local PS1 with a red, bold SSH between parentheses\., which identifies at a glance that the terminal window is an SSH session\.
+The default prepends the local PS1 with a red, bold SSH between parentheses\. This identifies, at a glance, that the terminal window is an SSH session\.
 _Default:_
 * SSHI\_RPS1='\\\[\\033\[1;1m\\\]\(\\\[\\033\[1;31m\\\]SSH\\\[\\033\[0;1m\\\]\)\\\[\\033\[0;37m\\\]$\{PS1\}'
 To remotely use your local PS1 unmodified, use the following:
@@ -42,7 +33,7 @@ _Default:_
 _Default:_
 * UNDEFINED
 
-_Omitting SSHI_MC \(main cnf\) avoids the need to override "host \*" in the user config, so you will probably not need to use it\._
+_Omitting SSHI\_MC \(main cnf\) avoids the need to override "host \*" in the user config, so you will probably not need to use it\._
 
 ### SSHI\_LOG\_BY\_DEF \- Enable local logging of SSH sessions by default\.
 _Default:_
@@ -62,7 +53,7 @@ _Log file names in this directory will be formatted as 'HOST\-YYYY\-MM\-DD_HH\-M
 _Default:_
 SSHI\_CREATE\_LOG\_LOC=1
 
-If SSHI\_CREATE\_LOG\_LOC is nonzero, the log destination directory (SSHI\_LOG\_LOC) will be created if it does not exist\.
+If SSHI\_CREATE\_LOG\_LOC is nonzero, the log destination directory \(SSHI\_LOG\_LOC) will be created if it does not exist\.
 
 ### SSHI\_NO\_LOG\_REMOTE \- Don't try to generate logs, when using ssh function in a remote SSH session\.
 _Default:_
@@ -82,26 +73,19 @@ SSHI\_LOG\_CMP\_BIN=gzip
 
 *The compresion tool specified by SSHI\_LOG\_CMP\_BIN must support reading from STDIN, and writing to STDOUT\.*
 
-SSHI\_LOG\_CMP\_OPTS \- Command-line options for compression tool (specified by SSHI\_LOG\_CMP\_BIN)\.
+SSHI\_LOG\_CMP\_OPTS \- Command\-line options for compression tool \(specified by SSHI\_LOG\_CMP\_BIN)\.
 _Default:_
 SSHI\_LOG\_CMP\_OPTS=-9
 
-SSHI\_LOG\_CMP\_AGE \- Set the minimum SSH log age (in days) for compression eligibility\.
+SSHI\_LOG\_CMP\_AGE \- Set the minimum SSH log age \(in days) for compression eligibility\.
 _Default:_
 SSHI\_LOG\_CMP\_AGE=3
 
-SSHI\_LOG\_MIN\_SIZE \- Minimum size (in bytes) an SSH log must be to avoid being deleted\.
+SSHI\_LOG\_MIN\_SIZE \- Minimum size \(in bytes) an SSH log must be to avoid being deleted\.
 _Default:_
 SSHI\_LOG\_MIN\_SIZE=512
 
-SSHI\_LOG\_FILT \- Optional filters to apply to log file output\.
-_Default:_
-*NOT SET*
-
-This can be used for "fixing" log output, such as masking passwords or omitting other items from the log\.
-*It does not affect the terminal output\.*
-
-When performing SSH log directory maintenance, delete old logs (see SSHI\_LOG\_CMP\_AGE) that a smaller than SSHI\_LOG\_MIN\_SIZE\.
+When performing SSH log directory maintenance, delete old logs \(see SSHI\_LOG\_CMP\_AGE) that are smaller than SSHI\_LOG\_MIN\_SIZE\.
 
 ### SSHI\_SSH\_BIN \- Location of SSH command\.
 _Default:_
@@ -110,41 +94,24 @@ SSHI\_SSH\_BIN=/usr/bin/ssh
 If the SSH command is in a different location, it can be defined using this option\.
 
 
-## Using \[SSH\_INCLUDE\] in your local bashrc\.
+## Using \[SSHI\_INCLUDE\] in your local bashrc\.
 *This gives you the ability to include parts of your bashrc that otherwise wouldn't be easily transferrable\.*
 If, for example, an external tool or function required commented lines or encoded data from your local bashrc, these could be made available to the user on the remote system\.
 This can also be used to include local environment variables on the remote system, but their definitions must be in the local \.bashrc\.
 
-To include lines from your bashrc, add "\# \[SSH\_INCLUDE\] XX" \(where XX is the number of lines\) to the line above the section you want\.
-
-
-# (TODO):
-## SSHI\_LOG\_FILT examples\.
-SSHI\_LOG\_FILT=(
-'^(enable\ password\ )(\S+)//\1\*\*\*\*\*\*\*\*'
-'^(enable\ secret\ )(\S+)//\1\*\*\*\*\*\*\*\*'
-'^passwd\ )(\S+)$//\1\*\*\*\*\*\*\*\*'
-'^(username\ \S+ password\ )(\S+)//\1\*\*\*\*\*\*\*\*'
-'^(username\ \S+ privilege\ \d+\ (secret|password)\ \d+\ )(\S+)//\1\*\*\*\*\*\*\*\*'
-
-'^( ikev1 pre-shared-key )(\S+)//\1\*\*\*\*\*\*\*\*'
-'^( ikev2 remote-authentication pre-shared-key )(\S+)//\1\*\*\*\*\*\*\*\*'
-'^( ikev2 local-authentication pre-shared-key )(\S+)//\1\*\*\*\*\*\*\*\*'
-'^( ospf message-digest-key \d+ \S+ )(\S+)//\1\*\*\*\*\*\*\*\*'
-'^( key \d+ )(\S+)//\1\*\*\*\*\*\*\*\*'
-)
+To include lines from your bashrc, add "\# \[SSHI\_INCLUDE\] XX" \(where XX is the number of lines\) to the line above the section you want\.
 
 ### Examples:
 
 Export the local EDITOR env variable on the remote system\.
 ```
-# [SSH_INCLUDE] 1
+# [SSHI_INCLUDE] 1
 export EDITOR='vim'
 ```
 
 Use 'addpath' function on remote session to manage PATH\.
 ```
-# [SSH_INCLUDE] 6
+# [SSHI_INCLUDE] 6
 #-- Android Dev Stuff...
 addpath ${HOME}/bin/android-studio/bin first
 addpath ${HOME}/bin/android-studio/sdk/tools first
@@ -153,7 +120,7 @@ addpath ${HOME}/bin/android-studio/sdk/build-tools/android-4.4.2 first
 export ANDROID_HOME=${HOME}/bin/android-studio/sdk
 ```
 
-*Lines marked by "\[SSH\_INCLUDE\] XX" are made available in the "\.bashrc\_pushed\-\[user\]\.funcs" file on the remote system\.*
+*Lines marked by "\[SSHI\_INCLUDE\] XX" are made available in the "\.bashrc\_pushed\-\[user\]\.funcs" file on the remote system\.*
 
 
 ## Overriding settings for hosts in the SSH config file\.
@@ -188,32 +155,33 @@ _This illustrates multiple options can be used per host entry\._
 
 ### Roadmap:
 * Get remote file shipping to work.
- 1. Just copy the files for now. Do not copy if the files are pre-existing\.
+ 1a. Just copy the files for now\. Do not copy if the files are pre\-existing\.
+ 1b. Eventually checksum both files, and copy if the contents differ\.
 
 * Additional functionality in file shipping:
  2. Generate checksums of each file to be included\.
   * Store these checksums on the remote host\. use them to compare local and remote copies\.
   * Only copy each file, if it either does not exist, or the checksums don't match\.
  3. New option "SSHI\_INC\_FILES\_ARCHIVE\_LOC"
-  * Used when including local files to the remote host\. This specifies a location to archive pre-existing remote files, before they are replaced by the local version\. This functionality is disabled if SSHI\_INC\_FILES\_ARCHIVE\_LOC is not set, or the matching host entry in the SSH config includes the "NO\_ARCHIVE\_REMOTE\_FILES" option\.
- 4. Add per-host override for SSHI\_INC\_FILES, allowing the ability to specify different files per-host.
+  * Used when including local files to the remote host\. This specifies a location to archive pre\-existing remote files, before they are replaced by the local version\. This functionality is disabled if SSHI\_INC\_FILES\_ARCHIVE\_LOC is not set, or the matching host entry in the SSH config includes the "NO\_ARCHIVE\_REMOTE\_FILES" option\.
+ 4. Add per\-host override for SSHI\_INC\_FILES, allowing the ability to specify different files per\-host\.
 
 ### Additional techinical details:
 
 ## Variable names and their function:
-R\_O - Returned output from last command iteration executed by \_sshi\_retry\_task\.
-RCPUSH - Defines the name of the pushed \.bashrc file (\.bashrc\_pushed-[username])\.
-S\_A - Holder for aliases to be packaged and included in remote SSH session\.
-S\_BD - Holds Perl BASE64 decoder script.
-S\_BE - Holds Perl BASE64 encoder script.
-S\_E - Used as boolean. Set as true when trying to determine if the session log can be written to\.
-S\_F - Set by _sshi_scancnf function when an SSH Host entry was matched in the SSH config(s)\.
-S\_LFM - Defines the name format of the session's log file\.
-S\_LF - Defines the full path of the session log file\.
-S\_LG - Used as boolean. Set by _sshi_scancnf, when the SSH config host entry has the "LOG" option defined\.
-S\_NL - Used as boolean. Set by _sshi_scancnf, when the SSH config host entry has the "NOLOG" option defined\.
-SSHREMCMD - Holder for the commands to run on the remote SSH session, in order to set up the environment\.
-SSHEXEC - Full SSH command to execute, including contents of S\_SC\.
-SSHI\_IS\_SSH - Used as boolean. This is an environment variable set in SSH session, to help determine if we are actively in an SSH session\.
+R\_O \- Returned output from last command iteration executed by \_sshi\_retry\_task\.
+RCPUSH \- Defines the name of the pushed \.bashrc file \(\.bashrc\_pushed\-\[username\]\)\.
+S\_A \- Holder for aliases to be packaged and included in remote SSH session\.
+S\_BD \- Holds Perl BASE64 decoder script\.
+S\_BE \- Holds Perl BASE64 encoder script\.
+S\_E \- Used as boolean. Set as true when trying to determine if the session log can be written to\.
+S\_F \- Set by \_sshi\_scancnf function when an SSH Host entry was matched in the SSH config\(s\)\.
+S\_LFM \- Defines the name format of the session's log file\.
+S\_LF \- Defines the full path of the session log file\.
+S\_LG \- Used as boolean. Set by \_sshi\_scancnf, when the SSH config host entry has the "LOG" option defined\.
+S\_NL \- Used as boolean. Set by \_sshi\_scancnf, when the SSH config host entry has the "NOLOG" option defined\.
+SSHREMCMD \- Holder for the commands to run on the remote SSH session, in order to set up the environment\.
+SSHEXEC \- Full SSH command to execute, including contents of S\_SC\.
+SSHI\_IS\_SSH \- Used as boolean\. This is an environment variable set in SSH session, to help determine if we are actively in an SSH session\.
 
 

--- a/files/command_not_found_handle
+++ b/files/command_not_found_handle
@@ -76,10 +76,10 @@ _rename_orig_command_not_found_handle () {
    || echo -e "export _COMMAND_TYPOS_INIT=1;\n${NEW}{ echo -ne \"\"; }"
 
    echo -e 'command_not_found_handle () {
-      EXITLVL=
-      INPUT_CMD=(${@})
-      CHECK=
-      RUN_CMD=()
+      local EXITLVL=
+      local INPUT_CMD=(${@})
+      local CHECK=
+      local RUN_CMD=()
       for C in "${INPUT_CMD[@]}"; do
          [ -n "${RUN_CMD[0]}" ] && {
             RUN_CMD=(${RUN_CMD} ${C})

--- a/files/ssh
+++ b/files/ssh
@@ -42,7 +42,6 @@
 # along with bashrc_enhancements.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
 #-- The '__sshi_l' alias is similar to 'tee', but is an embedded perl script.
 #  This allows for log output filtering (TODO), and keeps external tool
 #  dependencies to a minimum.
@@ -85,10 +84,21 @@ if(open(\$l,\">\",\$ARGV[0])){\$l->autoflush(1);STDOUT->autoflush(1);
 else{die(\"Problem writing to \\\"\".\$ARGV[0].\"\\\":\".\$!.\"\\n\");}
 sub out{if((length(\$b[1])>=\$mb)||(\$c eq \"\\r\"||\$c eq \"\\n\")){print \$l \$b[1];\$b[1]=undef;}}' --"
 
-
 #-- Modification of anything within this section requires you
 # to reread your rc or restart bash.
 ssh () {
+
+#-- Debugging output subroutine. Only logs output when SSHI_DBG > MSG_LVL.
+_sshi_debug () {
+ local MSG_LVL="${1}"
+ local MSG="${2}"
+ #- Skip debugging output when the destination file is undefined.
+ [ -n "${SSHI_DBG_DST}" ] && return
+ #- Skip debugging output when the message debug level is less than SSHI_DBG.
+ [ ${SSHI_DBG} -lt ${MSG_LVL} ] && return
+
+ echo -e "${MSG}" >> "${SSHI_DBG_DST}"
+}
 
 #-- Subroutine to set the configuration defaults, if no global overrides
 # have been set.
@@ -104,6 +114,8 @@ _sshi_defaults () {
   }
  done<<EOF
  SSHI_ADD_SUBS="sudo ssh tar addpath"
+ SSHI_DBG=4
+ SSHI_DBG_DST=
  SSHI_INC_FILES=()
  SSHI_INC_FILES_ARCHIVE_LOC=
  SSHI_RPS1='\[\e[1;1m\](\[\e[1;31m\]SSH\[\e[0;1m\])\[\e[0;37m\]${PS1}'
@@ -140,21 +152,22 @@ _sshi_scancnf () {
   [ ${C} -ge ${#CF[@]} ] && OP=(${OP[@]} ${O})
   C=$((${C}+1))
  done
-#-- SSH Command line option knowledge.
-# These are the known options for my installed OpenSSH version (v.7.2p2).
-#  (1)-  : Opts with NO argument. ( $sw )
-#  (2)-  : Opts WITH AN argument. ( $op )
-#  (3)-  : Decouple user@ prefix.
-#  (4)-  : Only host lines
-#  (5)-  : Escape wildcard types
-#  (6)-  : The first unrecognized option entered will be considered the "host".
-#  (7)-  : sh == SSH Host (and user, if defined).
-#  (8)-  : sc == SSH Remote Command
-#  (9)-  : If the SSH Host has been defined, we assume the first unregonized
-#          opt is a remote command to exec.
-#  (10)- : If the SSH Remote Command is nonzero, we assume that anything else
-#          is an option for the remote command.
-#  (11)- : so == SSH Opts
+
+ #- SSH Command line option knowledge.
+ # These are the known options for my installed OpenSSH version (v.7.2p2).
+ #  (1)-  : Opts with NO argument. ( $sw )
+ #  (2)-  : Opts WITH AN argument. ( $op )
+ #  (3)-  : Decouple user@ prefix.
+ #  (4)-  : Only host lines
+ #  (5)-  : Escape wildcard types
+ #  (6)-  : The first unrecognized option entered will be considered the "host".
+ #  (7)-  : sh == SSH Host (and user, if defined).
+ #  (8)-  : sc == SSH Remote Command
+ #  (9)-  : If the SSH Host has been defined, we assume the first unregonized
+ #          opt is a remote command to exec.
+ #  (10)- : If the SSH Remote Command is nonzero, we assume that anything else
+ #          is an option for the remote command.
+ #  (11)- : so == SSH Opts
  cat ${CF[@]} | perl -e '
  sub o{
   $r="^\\s*$_[1]";print "local ".$_[0]."\n"if((!$_[1])||(grep(/$r/,@{$_[2]})));
@@ -218,10 +231,10 @@ _sshi_clean_log_dir () {
   [ ${D} -ge ${SSHI_LOG_CMP_AGE} ] && {
    [ ${S} -lt ${SSHI_LOG_MIN_SIZE} ] && {
     echo "Removing ${L} (Size is ${S} bytes. Minimum size is ${SSHI_LOG_MIN_SIZE})."
-    rm ${L}
+    eval "$(_sshi_retry_task 2 2 rm -f ${L})"
    } || {
     echo "Compressing ${L}"
-    ${SSHI_LOG_CMP_BIN} ${SSHI_LOG_CMP_OPTS} ${L}
+    eval "$(_sshi_retry_task ${SSHI_LOG_CMP_BIN} ${SSHI_LOG_CMP_OPTS} ${L})"
    }
   }
  done
@@ -256,24 +269,53 @@ _sshi_package_include_files () {
 }
 
 #-- Retry execution of a task for a maximum number of tries, pausing
-# every 0.1$RANDOM seconds.
+# every 0.1[random] seconds.
+#
+# This is called using an eval. It outputs the results as R_O and R_T.
 _sshi_retry_task () {
   local OP=(${@})
   #- MR == Max. Retries before giving up.
-  local MR=${OP[0]}
-  OP[0]=
+  # Default is 2.
+  local MR=2
+  [[ "${OP[0]}" =~ ^[0-9\.]+$ ]] && {
+   MR=${OP[0]}
+   OP=("${OP[@]:1}")
+  }
+  #- TO == Wait this long for command to complete before failing the task.
+  # Default is 0 (infinite).
+  local TO=0
+  [[ "${OP[0]}" =~ ^[0-9\.]+$ ]] && {
+   TO=${OP[0]}
+   OP=("${OP[@]:1}")
+  }
   local OUT=
   local LP=1
   local CT=0
   while [ ${LP} -ge 1 ]; do
    CT=$((${CT}+1))
-   eval "O=\"$(${OP[@]} 2>&1;echo "\";LP=${?}")"
-   OUT="${O}"
+   [ ${TO} -eq 0 ] && {
+    eval "OUT=\"$(${OP[@]}; LP=${?}; echo "\"; LP=${LP}")"
+   } || {
+    eval "OUT=\"$(START=${SECONDS};ERR=0;DONE=0;${OP[@]} 2>&1 || ERR=${?} & \
+     CHILDPID=${!};echo -e "\";LP=\"${ERR}"; \
+     while [ ${DONE} -lt 1 ]; do P=$(ps -ef|grep ${CHILDPID}|grep -v grep); \
+     [ -z "${P}" ] && { DONE=1; } || { \
+      [ $((${SECONDS} - ${START})) -ge ${TO} ] && { DONE=1; } || { \
+#       echo "------------------------------------------" >> psout; \
+#       echo "child pid: ${CHILDPID}" >> psout; \
+#       echo "cmd: \"${OP[@]}\"" >> psout; \
+#       ps -ef >> psout; \
+       sleep 0.2;DONE=0; \
+      };};done)\""
+#    echo -e "OUT \"${OUT}\"" 1>&2
+   }
+
    [ ${LP} -ge 1 ] && {
     [ ${CT} -ge ${MR} ] && break
     sleep "0.1${RANDOM}"
    }
   done
+
   echo -e "R_O=\"${OUT}\";R_T=${LP}"
 }
 
@@ -317,8 +359,7 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
   [ -n "${SSHI_LOG_LOC}" ] && {
    [ -n ${SSHI_CREATE_LOG_LOC} ] && {
     [ ! -e ${SSHI_LOG_LOC} ] && {
-     mkdir -p ${SSHI_LOG_LOC} || \
-      _sshi_err "Unable to create dir:\n   ${SSHI_LOG_LOC}."
+     eval "$(_sshi_retry_task 1 1 mkdir -p ${SSHI_LOG_LOC})"
     }
    }
   }
@@ -331,9 +372,9 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
   local OK=
 
   while [ -z "${OK}" ]; do
-   eval "$(_sshi_retry_task 2 rm ${WT})"
+   eval "$(_sshi_retry_task 2 2 rm -f ${WT})"
    S_E=$((${S_E}+${R_T}))
-   eval "$(_sshi_retry_task 2 touch ${WT})"
+   eval "$(_sshi_retry_task 2 2 touch ${WT})"
    S_E=$((${S_E}+${R_T}))
    [ ${S_E} = 0 ] && {
     OK=1
@@ -430,8 +471,9 @@ eval "${PC}"
   }
 
   #- Retrieve SSHI_ADD_SUBS functions and [SSH_INCLUDE] lines.
-  # Functions need to be decoded before 'source'ing them (for some reason). Decoded output is
-  # piped to RCPUSH.funcs file, which is sourced from the pushed rc file.
+  # Functions need to be decoded before 'source'ing them (for some reason).
+  # Decoded output is piped to RCPUSH.funcs file, which is sourced from the
+  # pushed rc file.
   local RFUNCS="export RCPUSH=${RCPUSH};$(_sshi_getrc ${RC} ${SSHI_ADD_SUBS})"
   local RFUNCS_E="sleep 0.2;echo \"$(echo "${RFUNCS}"|eval ${S_BE})\"|${S_BD}>~/${RCPUSH}.funcs;. ~/${RCPUSH}.funcs"
   RBASHRC_E="export SSHI_IS_SSH=1;${S_A}${RFUNCS_E};${RBASHRC}"
@@ -439,7 +481,6 @@ eval "${PC}"
   RBASHRC_E=${RBASHRC_E//\"/\\\"}
   [ -z "${SSHREMCMD}" ] &&
    SSHREMCMD="echo \"${RBASHRC_E}\">~/${RCPUSH};exec bash --rcfile ~/${RCPUSH}"
-
  }
 }
 

--- a/files/ssh
+++ b/files/ssh
@@ -1,13 +1,12 @@
 #- SSH interception subroutine with a lot great extras.
-# This was written originally to eliminate the need to copy or clone a custom .bashrc to remote systems,
+# This was written originally to eliminate the need to copy or clone a custom
+# .bashrc to remote systems,
 #
 # Author: Jeremy Melanson
-#
-# Source-code, documentation and revision Git repository: https://github.com/zish/bashrc_enhancements
-#
-# Author: Jeremy Melanson
-#
 # Last-Modified: 2016-09-08
+#
+# Source-code, documentation and revision Git repository:
+#  https://github.com/zish/bashrc_enhancements
 #
 # $ git clone https://github.com/zish/bashrc_enhancements
 #
@@ -16,11 +15,15 @@
 #
 # Features:
 #  * Allows you to take your PS1 prompt with you.
-#    - Prepends the remote prompt with "(SSH)", to visually indicate that it is an SSH session.
-#  * Any aliases defined locally at run time will be defined in your remote session automatically.
-#  * Select embedded functions can be cloned to your remote SSH session, by adding them to SSHI_ADD_SUBS, (defined below),
-#  * Specific ranges of ines in your .bashrc can be cloned to your remote SSH session, using
-#    a special '# [SSH_INCLUDE nn]' remarkbefore the lines without needing to copy them everywhere.
+#    - Prepends the remote prompt with "(SSH)", to visually indicate that it
+#     is an SSH session.
+#  * Any aliases defined locally at run time will be defined in your remote
+#     session automatically.
+#  * Select embedded functions can be cloned to your remote SSH session,
+#     by adding them to SSHI_ADD_SUBS, (defined below),
+#  * Specific ranges of ines in your .bashrc can be cloned to your remote
+#     SSH session, using a special '# [SSHI_INCLUDE nn]' remark before the
+#     lines without needing to copy them everywhere.
 #
 #
 # This file is part of bashrc_enhancements.
@@ -38,63 +41,60 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with bashrc_enhancements.  If not, see <http://www.gnu.org/licenses/>.
 
-#- This is similar to 'tee', but is an embedded perl script. This allows for log output filtering (TODO).
-#  -(1)- : \$mb == Maximum size of each buffer before filtering and flushing to log file.
-#          If you use a filter that requires a fairly long sample of characters, you may need to increase
-#          this number. Use this guide:
-#           1. Roughly estimate the maximum bytes needed to apply the filter. Rounding up is recommended.
-#           2. Multiply this number by 3.
-#           3. Modify \$mb=XXXX declaration in the alias to reflect this number.
-#          ** This alias uses 2 capture buffers, and runs filters against both, then halfway between them.
-#  -(2)- : \$b == Which data capture buffer to fill.
-#  -(3)- : @b == Data capture 'b'uffers. We flip between them to facilitate log filtering.
-#  -(4)- : \$o == 'o'verflow capture. This is for facilitating filtering. We don't want text cut between buffers.
-#  -(2)- : \$l == Output 'l'og filehandle.
-#  -(2)- : \$c == Holder for each 'c'haracter captured.
-alias __sshi_l="perl -MIO::Handle -e '#This is a required component for the SSH BaSH Intercept function.
-#part of the bashrc_enhancements project.
-use strict;
-my (\$l,\$c,\$o);
-my @b=(\"\");
-my \$b=1;
- my \$filt = \"^\\<--\\ More\\ ---\\>\" . chr (13);
- my \$mb=1000; #-(1)-
-
- exit(1)if(!\$ARGV[0]);
-
- \$SIG{INT}=\"IGNORE\";
- if(open(\$l,\">\",\$ARGV[0])){
-  \$l->autoflush(1);
-  STDOUT->autoflush(1);
-  while(!eof (STDIN)){
-   \$c=getc(STDIN);
-   print \$c;
-#-(2)-
-   if((length(\$b[1])>=\$mb)||(\$c eq \"\\r\"||\$c eq \"\\n\")){
-    out();
-   }
-   \$b[1].=\$c;
-  }
-  close(\$l);
- }else{
-  die(ord(7).ord(7).ord(7).\"Problem writing to \\\"\".\$ARGV[0].\"\\\":\".\$!.\"\\n\");
- }
-
-sub out{
- if((length(\$b[1])>=\$mb)||(\$c eq \"\\r\"||\$c eq \"\\n\")){
-  print \$l \$b[1];
-  \$b[1]=undef;
-# }else{
-
- }
-}' --"
 
 
+#-- The '__sshi_l' alias is similar to 'tee', but is an embedded perl script.
+#  This allows for log output filtering (TODO), and keeps external tool
+#  dependencies to a minimum.
+#
+#  ** SSHI WILL NOT USE THIS IF THE PROVIDED PERL VERSION IS < 5.18.       **
+#  ** IT WILL INSTEAD FALL BACK TO USING 'tail -i', WHICH DOES NOT PROVIDE **
+#  ** FILTERING CAPABILITIES.
+#
+# __ COMMENTS have been moved from embedded Perl, and replaced with pointers.__
+# __ This is to decrease the in-memory size of the ssh intercept function.   __
+# __ BaSH Comments are omitted from in-memory, but embedded strings          __
+# __  are left alone.                                                        __
+#
+#  (1)- : \$mb == Maximum size of each buffer before filtering and flushing
+#         to log file.
+#         If you use a filter that requires a fairly long sample of
+#         characters, you may need to increase this number. Use this guide:
+#          1. Roughly estimate the maximum bytes needed to apply the filter.
+#             Rounding up is recommended.
+#          2. Multiply this number by 3.
+#          3. Modify \$mb=XXXX declaration in the alias to reflect
+#             this number.
+#         ** This alias uses 2 capture buffers, and runs filters against both,
+#         ** then halfway between them.
+#  (2)- : \$b == Which data capture buffer to fill.
+#  (3)- : @b == Data capture 'b'uffers. We flip between them to facilitate log
+#          filtering.
+#  (4)- : \$o == 'o'verflow capture. This is for facilitating filtering.
+#         We don't want text cut between buffers.
+#  (2)- : \$l == Output 'l'og filehandle.
+#  (2)- : \$c == Holder for each 'c'haracter captured.
+alias __sshi_l="perl -MIO::Handle -e '# This is a required component for the SSH BaSH Intercept function.
+# part of the bashrc_enhancements project.
+my(\$b,\$mb,\$l,\$c,\$o)=(1,1000);my@b=(\"\");
+exit(1)if(!\$ARGV[0]);\$SIG{INT}=\"IGNORE\";
+if(open(\$l,\">\",\$ARGV[0])){\$l->autoflush(1);STDOUT->autoflush(1);
+ while(!eof(STDIN)){\$c=getc(STDIN);print \$c;
+  if((length(\$b[1])>=\$mb)||(\$c eq \"\\r\"||\$c eq \"\\n\")){out();}\$b[1].=\$c;}
+ close(\$l);}
+else{die(\"Problem writing to \\\"\".\$ARGV[0].\"\\\":\".\$!.\"\\n\");}
+sub out{if((length(\$b[1])>=\$mb)||(\$c eq \"\\r\"||\$c eq \"\\n\")){print \$l \$b[1];\$b[1]=undef;}}' --"
 
-#- Modification of anything within this section requires you to reread your rc or restart bash.
+
+#-- Modification of anything within this section requires you
+# to reread your rc or restart bash.
 ssh () {
-#- Set the configuration defaults, if no global override have been set.
-# ** DO NOT MODIFY THESE DIRECTLY. THEY SHOULD BE DEFINED IN YOUR LOCAL bashrc. **
+
+#-- Subroutine to set the configuration defaults, if no global overrides
+# have been set.
+#
+# ** DO NOT MODIFY THESE DIRECTLY. THEY      **
+# ** SHOULD BE DEFINED IN YOUR LOCAL bashrc. **
 _sshi_defaults () {
  local IFS=$'\n'
  while read -r L; do
@@ -122,15 +122,15 @@ _sshi_defaults () {
 EOF
 }
 
-#- Format and output local error messages.
+#-- Format and output local error messages.
 _sshi_err () {
- local S="****************"
- echo -ne "${S}\n\a\a\aWARNING: ${1}${S}\n"
+ local S="****************\n"
+ echo -e "${S}\a\a\aWARNING: ${1}${S}"
 }
 
-#- Get SSH hostname and scan conf(s). Missing files are ignored.
+#-- Get SSH hostname and scan conf(s). Missing files are ignored.
+# $1 is user config. $2 is main conf. Rest are SSH options.
 _sshi_scancnf () {
-#- $1 is user config. $2 is main conf. Rest are SSH options.
  local CF=()
  local OP=()
  [ -f "${1}" ] && CF=(${1})
@@ -140,32 +140,26 @@ _sshi_scancnf () {
   [ ${C} -ge ${#CF[@]} ] && OP=(${OP[@]} ${O})
   C=$((${C}+1))
  done
-#- SSH Command line option knowledge.
+#-- SSH Command line option knowledge.
 # These are the known options for my installed OpenSSH version (v.7.2p2).
-#- COMMENTS have been moved from embedded Perl, and replaced with pointers.
-# This is to decrease the in-memory size of the ssh intercept function.
-# BaSH Comments are omitted from in-memory, but embedded strings are left alone.
-#  -(1)- : Opts with NO argument. ( $sw )
-#  -(2)- : Opts WITH AN argument. ( $op )
-#  -(3)- : Decouple user@ prefix.
-#  -(4)- : Only host lines
-#  -(5)- : Escape wildcard types
+#  (1)- : Opts with NO argument. ( $sw )
+#  (2)- : Opts WITH AN argument. ( $op )
+#  (3)- : Decouple user@ prefix.
+#  (4)- : Only host lines
+#  (5)- : Escape wildcard types
  cat ${CF[@]} | perl -e '
   sub o{$l="local ";$r="^\\s*$_[1]";print $l.$_[0]."\n"if((!$_[1])||(grep(/$r/,@{$_[2]})));}
-  $sw="^\\-[1246AaCfGgKkMNnsTtVvXxYy]";$op="^\\bcDEeFIiLlmOopQqRSWw]"; #-(1)- & -(2)-
+  $sw="^\\-[1246AaCfGgKkMNnsTtVvXxYy]";$op="^\\bcDEeFIiLlmOopQqRSWw]"; #(1)- & (2)-
   $sh="";while($ar=shift(@ARGV)){if($ar=~/$op/){shift(@ARGV);}elsif(!($ar=~/$sw/)){$sh=$ar;}}
-  $sh=~s/^\w+\@//;o("SSH_HOST=$sh");while(<STDIN>){ #-(3)-
-   $p=$_;%rt=("\\."=>"\\.","\\*"=>".*","\\?"=>"."); #-(4)-
-   if($p=~/^\s*host\s+([^\#]+)\#?([^\#]*)/i){ #-(5)-
+  $sh=~s/^\w+\@//;o("SSH_HOST=$sh");while(<STDIN>){ #(3)-
+   $p=$_;%rt=("\\."=>"\\.","\\*"=>".*","\\?"=>"."); #(4)-
+   if($p=~/^\s*host\s+([^\#]+)\#?([^\#]*)/i){ #(5)-
     $ch=$1;$a=$2;@h=($ch=~/([^\s\,]+)/g);foreach $H(@h){
-     foreach $e(sort{$b cmp $a}(keys(%rt))){$H=~s/$e/$rt{$e}/g;} #-(6)-
-     $H="^($H)\$";if($sh=~/$H/){@O=split(/\s*\,\s*/,$a);
-      o("S_F=$sh");o("S_LG=1","LOGFILE",\@O);
-      o("S_NL=1","NOLOG",\@O);o("NOPROMPT=1","NOPROMPT",\@O);
-      o("PROMPTONLY=1","PROMPTONLY",\@O);exit;}}}}' -- ${OP[@]}
+     foreach $e(sort{$b cmp $a}(keys(%rt))){$H=~s/$e/$rt{$e}/g;} #(6)-
+     $H="^($H)\$";if($sh=~/$H/){@O=split(/\s*\,\s*/,$a);o("S_F=$sh");o("S_LG=1","LOGFILE",\@O);o("S_NL=1","NOLOG",\@O);o("NOPROMPT=1","NOPROMPT",\@O);o("PROMPTONLY=1","PROMPTONLY",\@O);exit;}}}}' -- ${OP[@]}
 }
 
-#- Clean the SSH Logs dir.
+#-- Clean the SSH Logs dir.
 # Removes .log files smaller than ${SSHI_LOG_MIN_SIZE} and compress .log files
 # older than ${SSHI_LOG_CMP_AGE}.
 _sshi_clean_log_dir () {
@@ -182,6 +176,7 @@ _sshi_clean_log_dir () {
   return
  }
  local F=
+ #- TODO: Replace find/grep with native BaSH or embedded Perl.
  for F in $(find ${SSHI_LOG_LOC} -maxdepth 1 -printf "%Cs %s %p\n"|grep -e "\.log$"); do
   [[ "${F}" =~ ^([0-9]+)\ ([0-9]+)\ (.*) ]] && {
    local D="$(((${CT}-${BASH_REMATCH[1]})/86400))"
@@ -200,24 +195,24 @@ _sshi_clean_log_dir () {
  done
 }
 
-#- Pull requested functions defined by SSHI_ADD_SUBS.
+#-- Pull requested functions defined by SSHI_ADD_SUBS.
 # and lines in rc file marked by [SSHI_INCLUDE XX] remarks.
 #  -(1)- : $b stands for {b}rackets.
 #  -(2)- : Grab [SSHI_INCLUDE] sections in bashrc.
-#          * GETS BOTH SSH_INCLUDE AND SSHI_INCLUDE. The former will be deprecated soon.
+#          * GETS BOTH SSH_INCLUDE AND SSHI_INCLUDE.
+#            SSH_INCLUDE will be deprecated in the near future.
 _sshi_getrc () {
  set | /usr/bin/perl -e '$rc=shift(@ARGV);my%addSubs;foreach my$f(@ARGV){$addSubs{$f}=1;}
-  my$b;foreach my$l(<STDIN>){
-   if($l=~/^\s*(\S+)\s+\([^\(\)]*\)\s*$/){$b=$1;} #-(1)-
-   print $l if($addSubs{$b});$b=undef if($l=~/^\}\s*([\;\#]?.*)/);}
-  my$rcFh;open($rcFh,"<",$rc)||die("Cannot open rc file $rc: $!");
-  my@rc=<$rcFh>;close($rcFh);
-  my($i,$c,$incPos);foreach my$l(@rc){ #-(2)-
-   if($l=~/^\s*\#\s*\[SSHI?_INCLUDE\]\s+(\d+)/){$i=$1;}
-   if($i){if($c<=$i){print$l;$c++;}else{$c=0;$i=0;}}}' -- ${@}
+ my$b;foreach my$l(<STDIN>){
+  if($l=~/^\s*(\S+)\s+\([^\(\)]*\)\s*$/){$b=$1;} #-(1)-
+  print $l if($addSubs{$b});$b=undef if($l=~/^\}\s*([\;\#]?.*)/);}
+ my$f;open($f,"<",$rc)||die("Cannot open rc file $rc: $!");my@rc=<$f>;close($f);
+ my($i,$c,$incPos);foreach my$l(@rc){ #-(2)-
+  if($l=~/^\s*\#\s*\[SSHI?_INCLUDE\]\s+(\d+)/){$i=$1;}
+  if($i){if($c<=$i){print$l;$c++;}else{$c=0;$i=0;}}}' -- ${@}
 }
 
-#- TODO: Package external files for inclusion.
+#-- TODO: Package external files for inclusion.
 _sshi_package_include_files () {
  for I in "${SSHI_INC_FILES[@]}"; do
   [[ ${I} =~ ^([^:]+):([^:]+)$ ]] && {
@@ -228,7 +223,8 @@ _sshi_package_include_files () {
  done
 }
 
-#- Retry execution of a task for a maximum number of tries, pausing every 0.1$RANDOM seconds.
+#-- Retry execution of a task for a maximum number of tries, pausing
+# every 0.1$RANDOM seconds.
 _sshi_retry_task () {
   local OP=(${@})
   #- MR == Max. Retries before giving up.
@@ -249,42 +245,44 @@ _sshi_retry_task () {
   echo -e "R_O=\"${OUT}\";R_T=${LP}"
 }
 
-#- Use Perl for BASE64 encode/decode. This eliminates the need to
+#-- Use Perl for BASE64 encode/decode. This eliminates the need to
 # keep track of different encode/decode tools and their cmd line opts.
 local S_BE="perl -MMIME::Base64 -e '\$f=join(\"\",<STDIN>);print encode_base64(\$f,\"\");'"
 local S_BD="perl -MMIME::Base64 -e '\$f=join(\"\",<STDIN>);print decode_base64(\$f);'"
 
-#- Get/set SSHI variable defaults.
+#-- Get/set SSHI variable defaults.
 eval "$(_sshi_defaults)"
 eval "$(_sshi_scancnf ${SSHI_UC} ${SSHI_MC} ${@})"
 
-#- Log file name format.
+#-- Log file name format.
 local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
-#- Determine if we should log.
+#-- Determine if we should log.
 [ -n "${SSHI_IS_SSH}" ] && [ -n "${SSHI_NO_LOG_REMOTE}" ] && {
  S_NL=1
  unset S_LF
 } || {
-# Log by default. Turn off logging when requested.
+ #- Log by default. Turn off logging when requested.
  [ -n "${SSHI_LOG_BY_DEF}" ] && {
   [ -n "${S_NL}" ] && unset S_LG S_NL || S_LG=1
  } || {
-# Do not log by default. Turn on logging when requested.
+ #- Do not log by default. Turn on logging when requested.
   [ -n "${S_LG}" ] && local S_LG=1
  }
-#- Make sure log location is writable.
+ #- Make sure log location is writable.
  [ -n "${S_LG}" ] && {
   local S_LF="${SSHI_LOG_LOC}/${S_LFM}"
  #- Create SSH log directory if needed.
   [ -n "${SSHI_LOG_LOC}" ] && {
    [ -n ${SSHI_CREATE_LOG_LOC} ] && {
     [ ! -e ${SSHI_LOG_LOC} ] && {
-     mkdir -p ${SSHI_LOG_LOC} || _sshi_err "Unable to create dir:\n   ${SSHI_LOG_LOC}."
+     mkdir -p ${SSHI_LOG_LOC} || \
+      _sshi_err "Unable to create dir:\n   ${SSHI_LOG_LOC}."
     }
    }
   }
   #- Make sure log directory is writeable. Try twice, after pausing for a bit.
-  # The length is randomized to compensate for > 2 simultaneous SSH sessions vying for the file.
+  # The length is randomized to compensate for > 2 simultaneous SSH sessions
+  # vying for the file.
   local WT=${SSHI_LOG_LOC}/.SSHI_WRITE_OK
   local S_E=0
   local OK=
@@ -314,34 +312,34 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
 #- Parse things and connect if we have a matched entry in the SSH config.
 [ -n "${S_F}" ] && {
  local SSHREMCMD= #- Holds contents of commands to run on remote host.
-#- PROMPTONLY set on a host .ssh/config. Set things accordingly.
+ #- PROMPTONLY set on a host .ssh/config. Set things accordingly.
  [ -n "${PROMPTONLY}" ] && {
   [ -n "${SSHI_RPS1}" ] && {
-   echo -e "Connecting to ${S_F} with local prompt.\n"
+   echo "Connecting to ${S_F} with local prompt."
    SSHREMCMD="export PS1=\"${SSHI_RPS1}\";exec bash"
   }
  } || {
- #- The rcfile to use remotely. Regenerates every time you log in.
- # local .bashrc will be called at the end. Overrides can be defined on the remote.
- # This variable is exported for use on remote systems.
+  #- The rcfile to use remotely. Regenerates every time you log in.
+  # local .bashrc will be called at the end. Overrides can be defined on the remote.
+  # This variable is exported for use on remote systems.
   [ -z "${RCPUSH}" ] && RCPUSH=".bashrc_pushed-${USER}"
- #- Add an alias to bash (use your customized bash env).
+  #- Add an alias to bash (use your customized bash env).
   local USH="alias bash='/bin/bash --rcfile ~/${RCPUSH}'"
- #- Code to determine user's local RC ( ${LRC} )
+  #- Code to determine user's local RC ( ${LRC} )
   local LRC='for F in .bashrc .bash_profile .profile;do [ -e ~/${F} ]&&{ echo ${F};break;};done'
   local RBASHRC='. $('"${LRC}"');'
   [ -n "${SSHI_RPS1}" ] && RBASHRC+="export PS1=\"${SSHI_RPS1}\""
   local RBASHRC_E
   echo -e "Connecting to ${S_F} with local shell includes.\n"
 
- #- Had a problem with the embedded __sshi_l alias with older Perl versions.
- # Not going to figure it out for now.
- # We fall back to "tee -i", if the version is lower than 5.18.
+  #- Had a problem with the embedded __sshi_l alias with older Perl versions.
+  # Not going to figure it out for now.
+  # We fall back to "tee -i", if the version is lower than 5.18.
   PC="perl -e 'use v5.18;' 2>/dev/null;[ \${?} -gt 0 ]&&{ echo;
    OPERL=1;echo '**** WARNING: Perl version is earlier than 5.18.     ****';
    echo '**** Using tee -i for logging (NO OUTPUT FILTERING). ****';echo;}"
   eval "${PC}"
- #- Gather aliases.
+  #- Gather aliases.
   local S_A=
   local OI=${IFS}
   IFS=$'\n'
@@ -355,10 +353,10 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
    S_A="${S_A}${A};"
   done
   IFS=${OI}
- #- Use RCPUSH file if in an SSH session. Allows you to reuse your shipped stuff when
- # using ssh on remote systems.
- # ** This only really matters when ssh is included in SSHI_ADD_SUBS.
- # Attempt to use pushed rc if SSH. Use local rc if non-SSH
+  #- Use RCPUSH file if in an SSH session. Allows you to reuse your shipped stuff when
+  # using ssh on remote systems.
+  # ** This only really matters when ssh is included in SSHI_ADD_SUBS.
+  # Attempt to use pushed rc if SSH. Use local rc if non-SSH
   local RC=
   [ -n "${SSHI_IS_SSH}" ] && [ -e "~/${RCPUSH}" ] && {
    RC="~/${RCPUSH}"
@@ -366,9 +364,9 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
   } || {
    RC=~/$(eval ${LRC})
   }
- #- Retrieve SSHI_ADD_SUBS functions and [SSH_INCLUDE] lines.
- # Functions need to be decoded before 'source'ing them (for some reason). Decoded output is
- # piped to RCPUSH.funcs file, which is sourced from the pushed rc file.
+  #- Retrieve SSHI_ADD_SUBS functions and [SSH_INCLUDE] lines.
+  # Functions need to be decoded before 'source'ing them (for some reason). Decoded output is
+  # piped to RCPUSH.funcs file, which is sourced from the pushed rc file.
   local RFUNCS="export RCPUSH=${RCPUSH};$(_sshi_getrc ${RC} ${SSHI_ADD_SUBS})"
   local RFUNCS_E="sleep 0.2;echo \"$(echo "${RFUNCS}"|eval ${S_BE})\"|${S_BD}>~/${RCPUSH}.funcs;. ~/${RCPUSH}.funcs"
   RBASHRC_E="export SSHI_IS_SSH=1;${S_A}${RFUNCS_E};${RBASHRC}"
@@ -377,7 +375,7 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
   local SSHREMCMD="echo \"${RBASHRC_E}\">~/${RCPUSH};exec bash --rcfile ~/${RCPUSH}"
  }
 }
-#- Compile the SSH command to run (including logging stuff) and run it.
+#-- Compile the SSH command to run (including logging stuff) and run it.
 local LC=
 local SSHEXEC=("${SSHI_SSH_BIN}" ${@})
 [ -n "${SSHREMCMD}" ] && SSHEXEC=(${SSHEXEC[@]} "-t" "${SSHREMCMD}")
@@ -393,16 +391,16 @@ local SSHEXEC=("${SSHI_SSH_BIN}" ${@})
 } || {
  ${SSHEXEC[*]}
 }
-#- Logging report.
-echo "------------------------------------------------"
+#-- Logging report.
+echo "------------------------------"
 [ -n "${S_LG}" ] && {
  [ -n "${S_LF}" ] && {
- #- Report the log file name, if it is not zero-length. Otherwise remove the file.
- #- Report the session log path, but not if zero-length.
+  #- Report the log file name, if it is not zero-length. Otherwise remove the file.
+  #- Report the session log path, but not if zero-length.
   [ -s "${S_LF}" ] && {
    echo "Session logged to ${S_LF}"
   } || {
-  #- Warn the user of zero-length log, and clear the file.
+   #- Warn the user of zero-length log, and clear the file.
    echo "No output logged from session. Removing ${S_LF}"
    rm "${S_LF}"
   }

--- a/files/ssh
+++ b/files/ssh
@@ -142,21 +142,53 @@ _sshi_scancnf () {
  done
 #-- SSH Command line option knowledge.
 # These are the known options for my installed OpenSSH version (v.7.2p2).
-#  (1)- : Opts with NO argument. ( $sw )
-#  (2)- : Opts WITH AN argument. ( $op )
-#  (3)- : Decouple user@ prefix.
-#  (4)- : Only host lines
-#  (5)- : Escape wildcard types
+#  (1)-  : Opts with NO argument. ( $sw )
+#  (2)-  : Opts WITH AN argument. ( $op )
+#  (3)-  : Decouple user@ prefix.
+#  (4)-  : Only host lines
+#  (5)-  : Escape wildcard types
+#  (6)-  : The first unrecognized option entered will be considered the "host".
+#  (7)-  : sh == SSH Host (and user, if defined).
+#  (8)-  : sc == SSH Remote Command
+#  (9)-  : If the SSH Host has been defined, we assume the first unregonized
+#          opt is a remote command to exec.
+#  (10)- : If the SSH Remote Command is nonzero, we assume that anything else
+#          is an option for the remote command.
+#  (11)- : so == SSH Opts
  cat ${CF[@]} | perl -e '
-  sub o{$l="local ";$r="^\\s*$_[1]";print $l.$_[0]."\n"if((!$_[1])||(grep(/$r/,@{$_[2]})));}
-  $sw="^\\-[1246AaCfGgKkMNnsTtVvXxYy]";$op="^\\bcDEeFIiLlmOopQqRSWw]"; #(1)- & (2)-
-  $sh="";while($ar=shift(@ARGV)){if($ar=~/$op/){shift(@ARGV);}elsif(!($ar=~/$sw/)){$sh=$ar;}}
-  $sh=~s/^\w+\@//;o("SSH_HOST=$sh");while(<STDIN>){ #(3)-
-   $p=$_;%rt=("\\."=>"\\.","\\*"=>".*","\\?"=>"."); #(4)-
-   if($p=~/^\s*host\s+([^\#]+)\#?([^\#]*)/i){ #(5)-
-    $ch=$1;$a=$2;@h=($ch=~/([^\s\,]+)/g);foreach $H(@h){
-     foreach $e(sort{$b cmp $a}(keys(%rt))){$H=~s/$e/$rt{$e}/g;} #(6)-
-     $H="^($H)\$";if($sh=~/$H/){@O=split(/\s*\,\s*/,$a);o("S_F=$sh");o("S_LG=1","LOGFILE",\@O);o("S_NL=1","NOLOG",\@O);o("NOPROMPT=1","NOPROMPT",\@O);o("PROMPTONLY=1","PROMPTONLY",\@O);exit;}}}}' -- ${OP[@]}
+ sub o{
+  $r="^\\s*$_[1]";print "local ".$_[0]."\n"if((!$_[1])||(grep(/$r/,@{$_[2]})));
+ }
+ $sw="^\\-[1246AaCfGgKkMNnsTtVvXxYy]";
+ $op="^\\-[bcDEeFIiLlmOopQqRSWw]"; #(1)- & (2)-
+ $sh=""; #(7)-
+ @so=(); #(11)-
+ @sc=(); #(8)-
+ while($ar=shift(@ARGV)){
+  if(@sc){push(@sc,$ar);} #(10)-
+  elsif($ar=~/$op/){push(@so,$ar); push(@so,shift(@ARGV));}
+  elsif(($ar=~/$sw/)){push(@so,$ar);}
+  else{
+   if(!$sh){$sh=$ar;} #(6)-
+   else{push(@sc,$ar);} #(9)-
+ }}
+ push(@so,$sh);$sh=~/^((\w+)\@)?([\w\.\-_]+)/;o("SSH_HOST=$3");$sh=$3;
+ o("SSHREMCMD=\"".join(" ",@sc)."\"");o("SSH_OPTS=\"".join(" ",@so)."\"");
+ while(<STDIN>){ #(3)-
+  $p=$_;
+  %rt=("\\."=>"\\.","\\*"=>".*","\\?"=>"."); #(4)-
+  if($p=~/^\s*host\s+([^\#]+)\#?([^\#]*)/i){ #(5)-
+   $ch=$1;$a=$2;@h=($ch=~/([^\s\,]+)/g);
+   foreach $H(@h){
+    foreach $e(sort{$b cmp $a}(keys(%rt))){$H=~s/$e/$rt{$e}/g;} #(6)-
+    $H="^($H)\$";
+    if($sh=~/$H/){@O=split(/\s*\,\s*/,$a);o("S_F=$sh");
+     o("S_LG=1","LOGFILE",\@O);
+     o("S_NL=1","NOLOG",\@O);
+     o("NOPROMPT=1","NOPROMPT",\@O);
+     o("PROMPTONLY=1","PROMPTONLY",\@O);
+     exit;
+ }}}}' -- ${OP[@]}
 }
 
 #-- Clean the SSH Logs dir.
@@ -250,28 +282,38 @@ _sshi_retry_task () {
 local S_BE="perl -MMIME::Base64 -e '\$f=join(\"\",<STDIN>);print encode_base64(\$f,\"\");'"
 local S_BD="perl -MMIME::Base64 -e '\$f=join(\"\",<STDIN>);print decode_base64(\$f);'"
 
+#-- This will be populated with our "log command".
+local LC=
+
 #-- Get/set SSHI variable defaults.
 eval "$(_sshi_defaults)"
 eval "$(_sshi_scancnf ${SSHI_UC} ${SSHI_MC} ${@})"
 
 #-- Log file name format.
 local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
+
 #-- Determine if we should log.
 [ -n "${SSHI_IS_SSH}" ] && [ -n "${SSHI_NO_LOG_REMOTE}" ] && {
  S_NL=1
  unset S_LF
+
 } || {
+
  #- Log by default. Turn off logging when requested.
  [ -n "${SSHI_LOG_BY_DEF}" ] && {
   [ -n "${S_NL}" ] && unset S_LG S_NL || S_LG=1
+
  } || {
+
  #- Do not log by default. Turn on logging when requested.
   [ -n "${S_LG}" ] && local S_LG=1
  }
+
  #- Make sure log location is writable.
  [ -n "${S_LG}" ] && {
   local S_LF="${SSHI_LOG_LOC}/${S_LFM}"
- #- Create SSH log directory if needed.
+
+  #- Create SSH log directory if needed.
   [ -n "${SSHI_LOG_LOC}" ] && {
    [ -n ${SSHI_CREATE_LOG_LOC} ] && {
     [ ! -e ${SSHI_LOG_LOC} ] && {
@@ -280,12 +322,14 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
     }
    }
   }
+
   #- Make sure log directory is writeable. Try twice, after pausing for a bit.
   # The length is randomized to compensate for > 2 simultaneous SSH sessions
   # vying for the file.
   local WT=${SSHI_LOG_LOC}/.SSHI_WRITE_OK
   local S_E=0
   local OK=
+
   while [ -z "${OK}" ]; do
    eval "$(_sshi_retry_task 2 rm ${WT})"
    S_E=$((${S_E}+${R_T}))
@@ -297,6 +341,7 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
     sleep "0.1${RANDOM}"
    }
   done
+
   [ ${S_E} -gt 0 ] && {
    _sshi_err "Unable to write to directory '${SSHI_LOG_LOC}'.\nSession will not be logged."
    unset S_LF
@@ -307,38 +352,56 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
  }
 } 
 
+#- Had a problem with the embedded __sshi_l alias with older Perl versions.
+# Not going to figure it out for now.
+# We fall back to "tee -i", if the version is lower than 5.18.
+PC="perl -e 'use v5.18;' 2>/dev/null;[ \${?} -gt 0 ]&&{ echo;
+ OPERL=1;echo '**** WARNING: Perl version is earlier than 5.18.     ****';
+ echo '**** Using tee -i for logging (NO OUTPUT FILTERING). ****';echo;}"
+eval "${PC}"
+
+#- A log file needs to be defined to log. Also, no logging when a remote
+# SSH command was entered via CLI.
+[ -n "${S_LF}" ] && [ -z "${SSHREMCMD}" ] && {
+ [ -z "${OPERL}" ] && {
+  LC="__sshi_l ${S_LF}"
+ } || {
+  LC="tee -i ${S_LF}"
+ }
+}
+
 #- Skip prompt and rc file shipping if requested.
 [ -n "${NOPROMPT}" ] && unset S_F
+
 #- Parse things and connect if we have a matched entry in the SSH config.
 [ -n "${S_F}" ] && {
- local SSHREMCMD= #- Holds contents of commands to run on remote host.
+
  #- PROMPTONLY set on a host .ssh/config. Set things accordingly.
  [ -n "${PROMPTONLY}" ] && {
   [ -n "${SSHI_RPS1}" ] && {
    echo "Connecting to ${S_F} with local prompt."
-   SSHREMCMD="export PS1=\"${SSHI_RPS1}\";exec bash"
+   [ -z "${SSHREMCMD}" ] &&
+    SSHREMCMD="export PS1=\"${SSHI_RPS1}\";exec bash"
   }
  } || {
+
   #- The rcfile to use remotely. Regenerates every time you log in.
   # local .bashrc will be called at the end. Overrides can be defined on the remote.
   # This variable is exported for use on remote systems.
   [ -z "${RCPUSH}" ] && RCPUSH=".bashrc_pushed-${USER}"
+
   #- Add an alias to bash (use your customized bash env).
   local USH="alias bash='/bin/bash --rcfile ~/${RCPUSH}'"
+
   #- Code to determine user's local RC ( ${LRC} )
   local LRC='for F in .bashrc .bash_profile .profile;do [ -e ~/${F} ]&&{ echo ${F};break;};done'
   local RBASHRC='. $('"${LRC}"');'
+
   [ -n "${SSHI_RPS1}" ] && RBASHRC+="export PS1=\"${SSHI_RPS1}\""
-  local RBASHRC_E
+
+  local RBASHRC_E=
   echo -e "Connecting to ${S_F} with local shell includes.\n"
 
-  #- Had a problem with the embedded __sshi_l alias with older Perl versions.
-  # Not going to figure it out for now.
-  # We fall back to "tee -i", if the version is lower than 5.18.
-  PC="perl -e 'use v5.18;' 2>/dev/null;[ \${?} -gt 0 ]&&{ echo;
-   OPERL=1;echo '**** WARNING: Perl version is earlier than 5.18.     ****';
-   echo '**** Using tee -i for logging (NO OUTPUT FILTERING). ****';echo;}"
-  eval "${PC}"
   #- Gather aliases.
   local S_A=
   local OI=${IFS}
@@ -353,6 +416,7 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
    S_A="${S_A}${A};"
   done
   IFS=${OI}
+
   #- Use RCPUSH file if in an SSH session. Allows you to reuse your shipped stuff when
   # using ssh on remote systems.
   # ** This only really matters when ssh is included in SSHI_ADD_SUBS.
@@ -364,6 +428,7 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
   } || {
    RC=~/$(eval ${LRC})
   }
+
   #- Retrieve SSHI_ADD_SUBS functions and [SSH_INCLUDE] lines.
   # Functions need to be decoded before 'source'ing them (for some reason). Decoded output is
   # piped to RCPUSH.funcs file, which is sourced from the pushed rc file.
@@ -372,44 +437,45 @@ local S_LFM="${SSH_HOST}-$(date +'%Y-%m-%d_%H-%M-%S').log"
   RBASHRC_E="export SSHI_IS_SSH=1;${S_A}${RFUNCS_E};${RBASHRC}"
   RBASHRC_E=${RBASHRC_E//\$/\\$}
   RBASHRC_E=${RBASHRC_E//\"/\\\"}
-  local SSHREMCMD="echo \"${RBASHRC_E}\">~/${RCPUSH};exec bash --rcfile ~/${RCPUSH}"
+  [ -z "${SSHREMCMD}" ] &&
+   SSHREMCMD="echo \"${RBASHRC_E}\">~/${RCPUSH};exec bash --rcfile ~/${RCPUSH}"
+
  }
 }
+
 #-- Compile the SSH command to run (including logging stuff) and run it.
-local LC=
-local SSHEXEC=("${SSHI_SSH_BIN}" ${@})
+local SSHEXEC=("${SSHI_SSH_BIN}" ${SSH_OPTS})
 [ -n "${SSHREMCMD}" ] && SSHEXEC=(${SSHEXEC[@]} "-t" "${SSHREMCMD}")
-[ -n "${S_LF}" ] && {
- [ -z "${OPERL}" ] && {
-  LC="__sshi_l ${S_LF}"
- } || {
-  LC="tee -i ${S_LF}"
- }
-}
+
 [ -n "${LC}" ] && {
  ${SSHEXEC[*]} | eval ${LC}
 } || {
  ${SSHEXEC[*]}
 }
+
 #-- Logging report.
-echo "------------------------------"
+[ -n "${LC}" ] && echo "------------------------------" 1>&2
 [ -n "${S_LG}" ] && {
  [ -n "${S_LF}" ] && {
+
   #- Report the log file name, if it is not zero-length. Otherwise remove the file.
   #- Report the session log path, but not if zero-length.
   [ -s "${S_LF}" ] && {
-   echo "Session logged to ${S_LF}"
+   echo "Session logged to ${S_LF}" 1>&2
   } || {
+
    #- Warn the user of zero-length log, and clear the file.
-   echo "No output logged from session. Removing ${S_LF}"
+   [ -n "${LC}" ] && echo "No output logged from session. Removing ${S_LF}" 1>&2
    rm "${S_LF}"
   }
+
  #- Warn the user that we were unable to write the session log.
  } || {
-  echo "WARNING: Logging is enabled, but unable to write to log. Verify SSHI_LOG_LOC is correct."
+  echo -ne "WARNING: Logging is enabled, but unable to write to log." 1>&2
+  echo -e " Please verify that SSHI_LOG_LOC is correct." 1>&2
  }
 }
 
-} # END ssh
+}
 
 # vim: filetype=sh tabstop=1 expandtab


### PR DESCRIPTION
Cleaned up code in ssh file.
Cleaned up documentation (fixed markdown, spacing, minor wording) in README.md and README.ssh.md

Added "_sshi_retry_task" function for managing maintenance tasks. It will retry a given amount of times during failure of the task, and optionally kill the task if it is still running after a given amount of time.
**Was running into a blocking issue with the 'rm' command, where it was waiting for input. Adding the '-f' flag fixed this, but there are several other locations in the code where a mechanism like this would be beneficial. _This is especially true when attempting to use it on multiple, dissimilar systems, where external tools may behave differently, or support different command-line options._**

Started work on embedded debugging tasks, but these will probably be removed.

Also performed some minor cleanup to command_not_found_handle. (_This should be in another PR, but I'm feeling too lazy._)