### PR TITLE
Add support to ssh for reading multiple source RCs.

### DIFF
--- a/README.ssh.md
+++ b/README.ssh.md
@@ -1,6 +1,6 @@
 # SSH Intercept function README
 
-This was written originally as a mechanism to bring my locally\-defined PS1 prompt and  bash aliases with me, so I didn't need to copy them everywhere\. It has since had a lot more functionality added to it\.
+This was written originally as a mechanism to bring my locally\-defined PS1 prompt and bash aliases with me, so I didn't need to copy them everywhere\. It has since had a lot more functionality added to it\.
 
 ### Features:
 * Define PS1 locally, and have it appear in remote SSH sessions\.
@@ -15,8 +15,16 @@ This was written originally as a mechanism to bring my locally\-defined PS1 prom
 *Defining these variables in your \.bashrc will override the default\.*
 
 ### SSHI\_ADD\_SUBS \- Specifies what locally\-defined functions to include in a remote SSH session\.
+The value should be a comma-separated list.
 _Default:_
-* SSHI\_ADD\_SUBS="sudo ssh tar addpath"
+* SSHI\_ADD\_SUBS="sudo, ssh, tar, addpath"
+
+### SSHI\_BASH\_RCFILES \- Specifies a list of "rc" files to read for [SSHI\INCLUDE] entries.
+The value should be a comma-separated list.
+_Default:_
+SSHI\_BASH\_RCFILES="${HOME}/.bashrc, ${HOME}/.bash\_profile, ${HOME}/.profile"
+
+_The files in the list are read in the order they are listed._
 
 ### SSHI\_RPS1 \- Remote PS1 Prompt\.
 The default prepends the local PS1 with a red, bold SSH between parentheses\. This identifies, at a glance, that the terminal window is an SSH session\.
@@ -43,7 +51,7 @@ Setting this to 0 or undefined will cause the function to skip local logging, un
 
 ### SSHI\_LOG\_LOC \- SSH local session log destination directory\.
 _Default:_
-SSHI\_LOG\_LOC=~/ssh\_logs
+* SSHI\_LOG\_LOC=~/ssh\_logs
 
 *The directory specified must exist for logging to occur\.*
 
@@ -51,48 +59,57 @@ _Log file names in this directory will be formatted as 'HOST\-YYYY\-MM\-DD_HH\-M
 
 ### SSHI\_CREATE\_LOG\_LOC \- Create the log destination dir, if it doesn't exist\.
 _Default:_
-SSHI\_CREATE\_LOG\_LOC=1
+* SSHI\_CREATE\_LOG\_LOC=1
 
 If SSHI\_CREATE\_LOG\_LOC is nonzero, the log destination directory \(SSHI\_LOG\_LOC) will be created if it does not exist\.
 
 ### SSHI\_NO\_LOG\_REMOTE \- Don't try to generate logs, when using ssh function in a remote SSH session\.
 _Default:_
-SSHI\_NO\_LOG\_REMOTE=1
+* SSHI\_NO\_LOG\_REMOTE=1
 
-No logging functions will be attempted, if SSHI\_NO\_LOG\_REMOTE is nonzero\.
+*No logging functions will be attempted, if SSHI\_NO\_LOG\_REMOTE is nonzero\.*
 
 SSHI\_LOG\_COMPRESS \- Compress SSH logs\.
 _Default:_
-SSHI\_LOG\_COMPRESS=1
+* SSHI\_LOG\_COMPRESS=1
 
-If SSHI\_LOG\_COMPRESS is nonzero, any SSH logs older than SSHI\_LOG\_CMP\_AGE will be compressed\.
+*If SSHI\_LOG\_COMPRESS is nonzero, any SSH logs older than SSHI\_LOG\_CMP\_AGE will be compressed\.*
 
 SSHI\_LOG\_CMP\_BIN \- SSH log compression tool to use\.
 _Default:_
-SSHI\_LOG\_CMP\_BIN=gzip
+* SSHI\_LOG\_CMP\_BIN=gzip
 
 *The compresion tool specified by SSHI\_LOG\_CMP\_BIN must support reading from STDIN, and writing to STDOUT\.*
 
 SSHI\_LOG\_CMP\_OPTS \- Command\-line options for compression tool \(specified by SSHI\_LOG\_CMP\_BIN)\.
 _Default:_
-SSHI\_LOG\_CMP\_OPTS=-9
+* SSHI\_LOG\_CMP\_OPTS=-9
 
 SSHI\_LOG\_CMP\_AGE \- Set the minimum SSH log age \(in days) for compression eligibility\.
 _Default:_
-SSHI\_LOG\_CMP\_AGE=3
+* SSHI\_LOG\_CMP\_AGE=3
 
 SSHI\_LOG\_MIN\_SIZE \- Minimum size \(in bytes) an SSH log must be to avoid being deleted\.
 _Default:_
-SSHI\_LOG\_MIN\_SIZE=512
+* SSHI\_LOG\_MIN\_SIZE=512
 
-When performing SSH log directory maintenance, delete old logs \(see SSHI\_LOG\_CMP\_AGE) that are smaller than SSHI\_LOG\_MIN\_SIZE\.
+*When performing SSH log directory maintenance, delete old logs \(see SSHI\_LOG\_CMP\_AGE) that are smaller than SSHI\_LOG\_MIN\_SIZE\.*
 
 ### SSHI\_SSH\_BIN \- Location of SSH command\.
 _Default:_
-SSHI\_SSH\_BIN=/usr/bin/ssh
+* SSHI\_SSH\_BIN=/usr/bin/ssh
 
-If the SSH command is in a different location, it can be defined using this option\.
+*If the SSH command is in a different location, it can be defined using this option\.*
 
+### SSHI\_DBG \- "Debug" level for performing debug tasks.
+_Default:_
+* SSHI\_DBG=4
+
+*A file must be specified in SSHI\_DBG\_DST to enable debugging output.*
+
+### SSHI\_DBG\_DST \- Destination file for debugging output.
+_Default:_
+* UNDEFINED
 
 ## Using \[SSHI\_INCLUDE\] in your local bashrc\.
 *This gives you the ability to include parts of your bashrc that otherwise wouldn't be easily transferrable\.*

--- a/files/ssh
+++ b/files/ssh
@@ -40,6 +40,18 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with bashrc_enhancements.  If not, see <http://www.gnu.org/licenses/>.
+#
+# TODO: Retroactive log file scrubbing, based on Perl REGEX.
+#       This is to provide the ability to store the SSH logs in a
+#       less-restricted manner.
+#
+#       Some ideas for scrubbing filters:
+#         - Credit cards
+#         - Mask Cisco pre-shared-keys, passwords, secrets
+#         - Remove existing and old passwords (as provided) from files.
+#           This requires hashing of files, and persistent storage, to
+#           enhance performance and remove the need to repeat files.
+#
 
 
 #-- The '__sshi_l' alias is similar to 'tee', but is an embedded perl script.
@@ -52,7 +64,7 @@
 #
 # __ COMMENTS have been moved from embedded Perl, and replaced with pointers.__
 # __ This is to decrease the in-memory size of the ssh intercept function.   __
-# __ BaSH Comments are omitted from in-memory, but embedded strings          __
+# __ Bash Comments are omitted from in-memory, but embedded strings          __
 # __  are left alone.                                                        __
 #
 #  (1)- : \$mb == Maximum size of each buffer before filtering and flushing
@@ -73,7 +85,7 @@
 #         We don't want text cut between buffers.
 #  (2)- : \$l == Output 'l'og filehandle.
 #  (2)- : \$c == Holder for each 'c'haracter captured.
-alias __sshi_l="perl -MIO::Handle -e '# This is a required component for the SSH BaSH Intercept function.
+alias __sshi_l="perl -MIO::Handle -e '# This is a required component for the SSH Bash Intercept function.
 # part of the bashrc_enhancements project.
 my(\$b,\$mb,\$l,\$c,\$o)=(1,1000);my@b=(\"\");
 exit(1)if(!\$ARGV[0]);\$SIG{INT}=\"IGNORE\";
@@ -113,7 +125,8 @@ _sshi_defaults () {
    echo "[ -z \"\${${BASH_REMATCH[1]}}\" ]&&local ${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
   }
  done<<EOF
- SSHI_ADD_SUBS="sudo ssh tar addpath"
+ SSHI_ADD_SUBS="ssh"
+ SSHI_BASH_RCFILES='"${HOME}/.bashrc","${HOME}/.bash_profile","${HOME}/.profile"'
  SSHI_DBG=4
  SSHI_DBG_DST=
  SSHI_INC_FILES=()
@@ -221,7 +234,7 @@ _sshi_clean_log_dir () {
   return
  }
  local F=
- #- TODO: Replace find/grep with native BaSH or embedded Perl.
+ #- TODO: Replace find/grep with native Bash or embedded Perl.
  for F in $(find ${SSHI_LOG_LOC} -maxdepth 1 -printf "%Cs %s %p\n"|grep -e "\.log$"); do
   [[ "${F}" =~ ^([0-9]+)\ ([0-9]+)\ (.*) ]] && {
    local D="$(((${CT}-${BASH_REMATCH[1]})/86400))"
@@ -242,19 +255,46 @@ _sshi_clean_log_dir () {
 
 #-- Pull requested functions defined by SSHI_ADD_SUBS.
 # and lines in rc file marked by [SSHI_INCLUDE XX] remarks.
-#  -(1)- : $b stands for {b}rackets.
-#  -(2)- : Grab [SSHI_INCLUDE] sections in bashrc.
+#  -(1)- : If there are any commas in the subroutine input list, we parse it
+#          as a comma-separated list. Otherwise, we parse is as if it were
+#          space-separated.
+#  -(2)- : $b stands for {b}rackets.
+#  -(3)- : Grab [SSHI_INCLUDE] sections in bashrc.
 #          * GETS BOTH SSH_INCLUDE AND SSHI_INCLUDE.
 #            SSH_INCLUDE will be deprecated in the near future.
 _sshi_getrc () {
- set | /usr/bin/perl -e '$rc=shift(@ARGV);my%addSubs;foreach my$f(@ARGV){$addSubs{$f}=1;}
- my$b;foreach my$l(<STDIN>){
-  if($l=~/^\s*(\S+)\s+\([^\(\)]*\)\s*$/){$b=$1;} #-(1)-
-  print $l if($addSubs{$b});$b=undef if($l=~/^\}\s*([\;\#]?.*)/);}
- my$f;open($f,"<",$rc)||die("Cannot open rc file $rc: $!");my@rc=<$f>;close($f);
- my($i,$c,$incPos);foreach my$l(@rc){ #-(2)-
-  if($l=~/^\s*\#\s*\[SSHI?_INCLUDE\]\s+(\d+)/){$i=$1;}
-  if($i){if($c<=$i){print$l;$c++;}else{$c=0;$i=0;}}}' -- ${@}
+ set | /usr/bin/perl -e '
+ @rc=split(/\s*,\s*/,shift(@ARGV));
+ my %addSubs;my $subsIn;my @subsIn;
+ if($subsIn=~/,/){ #-(1)-
+  @subsIn=split(/\s*\,\s*/,$ARGV[0]);
+ }else{
+  @subsIn=split(/\s*/,$ARGV[0]);
+ }
+ foreach my $f(split(/\s*,\s*/,shift(@ARGV))){
+  $f=~s/^\s*\"?//;$f=~s/\"?\s*$//;
+  $addSubs{$f}=1;
+ }
+ my $b;
+ foreach my $l(<STDIN>){
+  if($l=~/^\s*(\S+)\s+\([^\(\)]*\)\s*$/){$b=$1;} #-(2)-
+  print $l if($addSubs{$b});
+  $b=undef if($l=~/^\}\s*([\;\#]?.*)/);
+ }
+ foreach my $rcf(@rc) {
+  $rcf=~s/^\s*\"?//;$rcf=~s/\"?\s*$//;
+  if(!open(my $f,"<",$rcf)) {
+   print STDERR "Cannot open rc file $rcf: $!\n";
+   next;
+  }else{
+   my ($i,$c,$incPos);
+   foreach my $l(<$f>){ #-(3)-
+    if($l=~/^\s*\#\s*\[SSHI?_INCLUDE\]\s+(\d+)/){$i=$1;}
+    if($i){
+     if($c<=$i){print$l;$c++;}else{$c=0;$i=0;}
+   }}
+   close($f);
+ }}' -- "${1}" "${2}"
 }
 
 #-- TODO: Package external files for inclusion.
@@ -434,12 +474,6 @@ eval "${PC}"
   #- Add an alias to bash (use your customized bash env).
   local USH="alias bash='/bin/bash --rcfile ~/${RCPUSH}'"
 
-  #- Code to determine user's local RC ( ${LRC} )
-  local LRC='for F in .bashrc .bash_profile .profile;do [ -e ~/${F} ]&&{ echo ${F};break;};done'
-  local RBASHRC='. $('"${LRC}"');'
-
-  [ -n "${SSHI_RPS1}" ] && RBASHRC+="export PS1=\"${SSHI_RPS1}\""
-
   local RBASHRC_E=
   echo -e "Connecting to ${S_F} with local shell includes.\n"
 
@@ -462,21 +496,18 @@ eval "${PC}"
   # using ssh on remote systems.
   # ** This only really matters when ssh is included in SSHI_ADD_SUBS.
   # Attempt to use pushed rc if SSH. Use local rc if non-SSH
-  local RC=
-  [ -n "${SSHI_IS_SSH}" ] && [ -e "~/${RCPUSH}" ] && {
-   RC="~/${RCPUSH}"
-   echo "NN: ${RC}"
-  } || {
-   RC=~/$(eval ${LRC})
-  }
+  if [ -n "${SSHI_IS_SSH}" -a -e "~/${RCPUSH}" ]; then
+   SSHI_BASH_RCFILES="~/${RCPUSH}"
+  fi
 
   #- Retrieve SSHI_ADD_SUBS functions and [SSH_INCLUDE] lines.
   # Functions need to be decoded before 'source'ing them (for some reason).
   # Decoded output is piped to RCPUSH.funcs file, which is sourced from the
   # pushed rc file.
-  local RFUNCS="export RCPUSH=${RCPUSH};$(_sshi_getrc ${RC} ${SSHI_ADD_SUBS})"
+  local RFUNCS="export RCPUSH=${RCPUSH};$(_sshi_getrc "${SSHI_BASH_RCFILES}" "${SSHI_ADD_SUBS}")"
   local RFUNCS_E="sleep 0.2;echo \"$(echo "${RFUNCS}"|eval ${S_BE})\"|${S_BD}>~/${RCPUSH}.funcs;. ~/${RCPUSH}.funcs"
-  RBASHRC_E="export SSHI_IS_SSH=1;${S_A}${RFUNCS_E};${RBASHRC}"
+  RBASHRC_E="export SSHI_IS_SSH=1;${S_A}${RFUNCS_E}"
+  [ -n "${SSHI_RPS1}" ] && RBASHRC_E+=";export PS1=\"${SSHI_RPS1}\""
   RBASHRC_E=${RBASHRC_E//\$/\\$}
   RBASHRC_E=${RBASHRC_E//\"/\\\"}
   [ -z "${SSHREMCMD}" ] &&
@@ -500,7 +531,6 @@ local SSHEXEC=("${SSHI_SSH_BIN}" ${SSH_OPTS})
  [ -n "${S_LF}" ] && {
 
   #- Report the log file name, if it is not zero-length. Otherwise remove the file.
-  #- Report the session log path, but not if zero-length.
   [ -s "${S_LF}" ] && {
    echo "Session logged to ${S_LF}" 1>&2
   } || {


### PR DESCRIPTION
- Added SSHI_BASH_RCFILES config var for specifying one or more source Bash RC files.
- Updated format of SSHI_ADD_SUBS config var to be a comma-separated list. This was done for continuity, since the new SSHI_BASH_RCFILES requires this.
  - _sshi_getrc still supports the "old" space-separated format. Users do not need to refactor their configuration to use this update. *This functionality may be removed in the furture.*